### PR TITLE
Content-length parameter

### DIFF
--- a/lib/blitline.js
+++ b/lib/blitline.js
@@ -42,7 +42,7 @@ module.exports = function() {
         path: '/job',
         method: 'POST',
         headers: {
-          'Content-Length': body.length,
+          'Content-Length': Buffer.byteLength(body),
           'Content-Type': 'application/json'
         },
         rejectUnauthorized: true


### PR DESCRIPTION
Using 'Content-Length': body.length  causes problems when non-standard (.e.g polish) characters are used in json describing the job.
(See correct example at https://nodejs.org/api/http.html)